### PR TITLE
Fix/suppress reconnect popups without suppressing events

### DIFF
--- a/ci/dev/vscode.patch
+++ b/ci/dev/vscode.patch
@@ -689,7 +689,7 @@ index 3715cbb8e6ee41c3d9b5090918d243b723ae2d00..c65de8ad37e727d66da97a8f8b170cbc
 -
 -
 diff --git a/src/vs/platform/remote/common/remoteAgentConnection.ts b/src/vs/platform/remote/common/remoteAgentConnection.ts
-index 18d3d04fd20335975293e37b3b641120dd92da20..ddc85643fc414991bf885f099f982d9de1b9eae2 100644
+index 18d3d04fd20335975293e37b3b641120dd92da20..4ec77056f8b707cb9cfc6af28f995d644b127506 100644
 --- a/src/vs/platform/remote/common/remoteAgentConnection.ts
 +++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
 @@ -92,7 +92,7 @@ async function connectToRemoteExtensionHostAgent(options: ISimpleConnectionOptio
@@ -701,7 +701,7 @@ index 18d3d04fd20335975293e37b3b641120dd92da20..ddc85643fc414991bf885f099f982d9d
  			(err: any, socket: ISocket | undefined) => {
  				if (err || !socket) {
  					options.logService.error(`${logPrefix} socketFactory.connect() failed. Error:`);
-@@ -331,12 +331,16 @@ export const enum PersistentConnectionEventType {
+@@ -331,12 +331,17 @@ export const enum PersistentConnectionEventType {
  }
  export class ConnectionLostEvent {
  	public readonly type = PersistentConnectionEventType.ConnectionLost;
@@ -715,11 +715,12 @@ index 18d3d04fd20335975293e37b3b641120dd92da20..ddc85643fc414991bf885f099f982d9d
  		public readonly durationSeconds: number,
 -		private readonly cancellableTimer: CancelablePromise<void>
 +		private readonly cancellableTimer: CancelablePromise<void>,
-+		public readonly suppressPopup?: boolean
++		public readonly suppressPopup?: boolean,
++		public readonly forceDialog?: boolean
  	) { }
  
  	public skipWait(): void {
-@@ -345,12 +349,21 @@ export class ReconnectionWaitEvent {
+@@ -345,12 +350,21 @@ export class ReconnectionWaitEvent {
  }
  export class ReconnectionRunningEvent {
  	public readonly type = PersistentConnectionEventType.ReconnectionRunning;
@@ -741,14 +742,16 @@ index 18d3d04fd20335975293e37b3b641120dd92da20..ddc85643fc414991bf885f099f982d9d
  }
  export type PersistenConnectionEvent = ConnectionGainEvent | ConnectionLostEvent | ReconnectionWaitEvent | ReconnectionRunningEvent | ReconnectionPermanentFailureEvent;
  
-@@ -411,16 +424,20 @@ abstract class PersistentConnection extends Disposable {
+@@ -411,16 +425,22 @@ abstract class PersistentConnection extends Disposable {
  		}
  		const logPrefix = commonLogPrefix(this._connectionType, this.reconnectionToken, true);
  		this._options.logService.info(`${logPrefix} starting reconnecting loop. You can get more information with the trace log level.`);
 -		this._onDidStateChange.fire(new ConnectionLostEvent());
+-		const TIMES = [5, 5, 10, 10, 10, 10, 10, 30];
 +		let suppressPopup = true;
++		let forceDialog = false;
 +		this._onDidStateChange.fire(new ConnectionLostEvent(suppressPopup));
- 		const TIMES = [5, 5, 10, 10, 10, 10, 10, 30];
++		const TIMES = [1, 2, 3, 10, 10, 10, 10, 30];
 +		const SHOW_POPUP_ON_ATTEMPT = 2 // aka third attempt
 +		
  		const disconnectStartTime = Date.now();
@@ -756,15 +759,16 @@ index 18d3d04fd20335975293e37b3b641120dd92da20..ddc85643fc414991bf885f099f982d9d
  		do {
  			attempt++;
 +			suppressPopup = (attempt < SHOW_POPUP_ON_ATTEMPT) ? true : false
++			forceDialog = (attempt == SHOW_POPUP_ON_ATTEMPT)
  			const waitTime = (attempt < TIMES.length ? TIMES[attempt] : TIMES[TIMES.length - 1]);
  			try {
  				const sleepPromise = sleep(waitTime);
 -				this._onDidStateChange.fire(new ReconnectionWaitEvent(waitTime, sleepPromise));
-+				this._onDidStateChange.fire(new ReconnectionWaitEvent(waitTime, sleepPromise, suppressPopup));
++				this._onDidStateChange.fire(new ReconnectionWaitEvent(waitTime, sleepPromise, suppressPopup, forceDialog));
  
  				this._options.logService.info(`${logPrefix} waiting for ${waitTime} seconds before reconnecting...`);
  				try {
-@@ -433,7 +450,7 @@ abstract class PersistentConnection extends Disposable {
+@@ -433,7 +453,7 @@ abstract class PersistentConnection extends Disposable {
  				}
  
  				// connection was lost, let's try to re-establish it
@@ -3272,84 +3276,71 @@ index 94e7e7a4bac154c45078a1b5034e50634a7a43af..8164200dcef1efbc65b50eef9c270af3
  				this._dirnameKey.set(value ? dirname(value).fsPath : null);
  				this._pathKey.set(value ? value.fsPath : null);
 diff --git a/src/vs/workbench/contrib/remote/browser/remote.ts b/src/vs/workbench/contrib/remote/browser/remote.ts
-index 98573a206f14928fc3fdf18fe927cb75034e4ad1..3ffe27b816e2d0a630985a24dd1af910877c2295 100644
+index 98573a206f14928fc3fdf18fe927cb75034e4ad1..a031f76924abf8f10c510ea9c043f670c5b43074 100644
 --- a/src/vs/workbench/contrib/remote/browser/remote.ts
 +++ b/src/vs/workbench/contrib/remote/browser/remote.ts
-@@ -635,7 +635,7 @@ class VisibleProgress {
- 		return this._lastReport;
- 	}
- 
--	constructor(progressService: IProgressService, location: ProgressLocation, initialReport: string | null, buttons: string[], onDidCancel: (choice: number | undefined, lastReport: string | null) => void) {
-+	constructor(progressService: IProgressService, location: ProgressLocation, initialReport: string | null, buttons: string[], onDidCancel: (choice: number | undefined, lastReport: string | null) => void, suppressPopup: Boolean | undefined) {
- 		this._isDisposed = false;
- 		this._lastReport = initialReport;
- 		this._currentProgressPromiseResolve = null;
-@@ -644,8 +644,10 @@ class VisibleProgress {
- 
- 		const promise = new Promise<void>((resolve) => this._currentProgressPromiseResolve = resolve);
- 
-+		const options = suppressPopup ? { location: location, buttons: buttons, silent: suppressPopup } : { location: location, buttons: buttons }
-+
- 		progressService.withProgress(
--			{ location: location, buttons: buttons },
-+			options,
- 			(progress) => { if (!this._isDisposed) { this._currentProgress = progress; } return promise; },
- 			(choice) => onDidCancel(choice, this._lastReport)
- 		);
-@@ -736,7 +738,7 @@ class RemoteAgentConnectionStatusListener implements IWorkbenchContribution {
- 			let reconnectWaitEvent: ReconnectionWaitEvent | null = null;
- 			let disposableListener: IDisposable | null = null;
- 
--			function showProgress(location: ProgressLocation.Dialog | ProgressLocation.Notification, buttons: { label: string, callback: () => void }[], initialReport: string | null = null): VisibleProgress {
-+			function showProgress(location: ProgressLocation.Dialog | ProgressLocation.Notification, buttons: { label: string, callback: () => void }[], initialReport: string | null = null, suppressPopup: Boolean | undefined): VisibleProgress {
- 				if (visibleProgress) {
- 					visibleProgress.dispose();
- 					visibleProgress = null;
-@@ -752,12 +754,12 @@ class RemoteAgentConnectionStatusListener implements IWorkbenchContribution {
- 							buttons[choice].callback();
- 						} else {
- 							if (location === ProgressLocation.Dialog) {
--								visibleProgress = showProgress(ProgressLocation.Notification, buttons, lastReport);
-+								visibleProgress = showProgress(ProgressLocation.Notification, buttons, lastReport, suppressPopup);
- 							} else {
- 								hideProgress();
- 							}
- 						}
--					}
-+					}, suppressPopup
- 				);
- 			}
- 
-@@ -796,17 +798,17 @@ class RemoteAgentConnectionStatusListener implements IWorkbenchContribution {
+@@ -795,31 +795,43 @@ class RemoteAgentConnectionStatusListener implements IWorkbenchContribution {
+ 				}
  				switch (e.type) {
  					case PersistentConnectionEventType.ConnectionLost:
- 						if (!visibleProgress) {
+-						if (!visibleProgress) {
 -							visibleProgress = showProgress(ProgressLocation.Dialog, [reconnectButton, reloadButton]);
-+							visibleProgress = showProgress(ProgressLocation.Notification, [reconnectButton, reloadButton], null, e.suppressPopup);
++						if (e.suppressPopup) {
++							hideProgress()
++						} else {
++							if (!visibleProgress) {
++								visibleProgress = showProgress(ProgressLocation.Dialog, [reconnectButton, reloadButton]);
++							}
++							visibleProgress.report(nls.localize('connectionLost', "Connection Lost"));	
  						}
- 						visibleProgress.report(nls.localize('connectionLost', "Connection Lost"));
+-						visibleProgress.report(nls.localize('connectionLost', "Connection Lost"));
  						break;
  					case PersistentConnectionEventType.ReconnectionWait:
  						reconnectWaitEvent = e;
 -						visibleProgress = showProgress(lastLocation || ProgressLocation.Notification, [reconnectButton, reloadButton]);
-+						visibleProgress = showProgress(lastLocation || ProgressLocation.Dialog, [reconnectButton, reloadButton], null, e.suppressPopup);
- 						visibleProgress.startTimer(Date.now() + 1000 * e.durationSeconds);
+-						visibleProgress.startTimer(Date.now() + 1000 * e.durationSeconds);
++						if (e.suppressPopup) {
++							hideProgress()
++						} else {
++							const location = e.forceDialog ? ProgressLocation.Dialog : (lastLocation || ProgressLocation.Notification)
++							visibleProgress = showProgress(location, [reconnectButton, reloadButton]);
++							visibleProgress.startTimer(Date.now() + 1000 * e.durationSeconds);	
++						}
  						break;
  					case PersistentConnectionEventType.ReconnectionRunning:
 -						visibleProgress = showProgress(lastLocation || ProgressLocation.Notification, [reloadButton]);
-+						visibleProgress = showProgress(lastLocation || ProgressLocation.Notification, [reloadButton], null, e.suppressPopup);
- 						visibleProgress.report(nls.localize('reconnectionRunning', "Attempting to reconnect..."));
- 
- 						// Register to listen for quick input is opened
-@@ -815,7 +817,7 @@ class RemoteAgentConnectionStatusListener implements IWorkbenchContribution {
- 							if (contextKeyChangeEvent.affectsSome(reconnectInteraction)) {
- 								// Need to move from dialog if being shown and user needs to type in a prompt
- 								if (lastLocation === ProgressLocation.Dialog && visibleProgress !== null) {
+-						visibleProgress.report(nls.localize('reconnectionRunning', "Attempting to reconnect..."));
+-
+-						// Register to listen for quick input is opened
+-						disposableListener = contextKeyService.onDidChangeContext((contextKeyChangeEvent) => {
+-							const reconnectInteraction = new Set<string>([inQuickPickContextKeyValue]);
+-							if (contextKeyChangeEvent.affectsSome(reconnectInteraction)) {
+-								// Need to move from dialog if being shown and user needs to type in a prompt
+-								if (lastLocation === ProgressLocation.Dialog && visibleProgress !== null) {
 -									visibleProgress = showProgress(ProgressLocation.Notification, [reloadButton], visibleProgress.lastReport);
-+									visibleProgress = showProgress(ProgressLocation.Notification, [reloadButton], visibleProgress.lastReport, e.suppressPopup);
++						if (e.suppressPopup) {
++							hideProgress()
++						} else {
++							visibleProgress = showProgress(lastLocation || ProgressLocation.Notification, [reloadButton]);
++							visibleProgress.report(nls.localize('reconnectionRunning', "Attempting to reconnect..."));
++	
++							// Register to listen for quick input is opened
++							disposableListener = contextKeyService.onDidChangeContext((contextKeyChangeEvent) => {
++								const reconnectInteraction = new Set<string>([inQuickPickContextKeyValue]);
++								if (contextKeyChangeEvent.affectsSome(reconnectInteraction)) {
++									// Need to move from dialog if being shown and user needs to type in a prompt
++									if (lastLocation === ProgressLocation.Dialog && visibleProgress !== null) {
++										visibleProgress = showProgress(ProgressLocation.Notification, [reloadButton], visibleProgress.lastReport);
++									}
  								}
- 							}
- 						});
+-							}
+-						});
+-
++							});
++						}
+ 						break;
+ 					case PersistentConnectionEventType.ReconnectionPermanentFailure:
+ 						hideProgress();
 diff --git a/src/vs/workbench/contrib/scm/browser/media/scm.css b/src/vs/workbench/contrib/scm/browser/media/scm.css
 index ac44ad3bae428def66e22fe9cc1c54648d429f6b..faa63023c4c586b51fa3c2a48ff3641b9cb0e145 100644
 --- a/src/vs/workbench/contrib/scm/browser/media/scm.css

--- a/ci/dev/vscode.patch
+++ b/ci/dev/vscode.patch
@@ -689,7 +689,7 @@ index 3715cbb8e6ee41c3d9b5090918d243b723ae2d00..c65de8ad37e727d66da97a8f8b170cbc
 -
 -
 diff --git a/src/vs/platform/remote/common/remoteAgentConnection.ts b/src/vs/platform/remote/common/remoteAgentConnection.ts
-index 18d3d04fd20335975293e37b3b641120dd92da20..48ba6434bd5fbd96919b1e109f350016b97aadc0 100644
+index 18d3d04fd20335975293e37b3b641120dd92da20..ddc85643fc414991bf885f099f982d9de1b9eae2 100644
 --- a/src/vs/platform/remote/common/remoteAgentConnection.ts
 +++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
 @@ -92,7 +92,7 @@ async function connectToRemoteExtensionHostAgent(options: ISimpleConnectionOptio
@@ -701,15 +701,78 @@ index 18d3d04fd20335975293e37b3b641120dd92da20..48ba6434bd5fbd96919b1e109f350016
  			(err: any, socket: ISocket | undefined) => {
  				if (err || !socket) {
  					options.logService.error(`${logPrefix} socketFactory.connect() failed. Error:`);
-@@ -413,6 +413,8 @@ abstract class PersistentConnection extends Disposable {
+@@ -331,12 +331,16 @@ export const enum PersistentConnectionEventType {
+ }
+ export class ConnectionLostEvent {
+ 	public readonly type = PersistentConnectionEventType.ConnectionLost;
++	constructor(
++		public readonly suppressPopup?: boolean
++	) { }
+ }
+ export class ReconnectionWaitEvent {
+ 	public readonly type = PersistentConnectionEventType.ReconnectionWait;
+ 	constructor(
+ 		public readonly durationSeconds: number,
+-		private readonly cancellableTimer: CancelablePromise<void>
++		private readonly cancellableTimer: CancelablePromise<void>,
++		public readonly suppressPopup?: boolean
+ 	) { }
+ 
+ 	public skipWait(): void {
+@@ -345,12 +349,21 @@ export class ReconnectionWaitEvent {
+ }
+ export class ReconnectionRunningEvent {
+ 	public readonly type = PersistentConnectionEventType.ReconnectionRunning;
++	constructor(
++		public readonly suppressPopup?: boolean
++	) { }
+ }
+ export class ConnectionGainEvent {
+ 	public readonly type = PersistentConnectionEventType.ConnectionGain;
++	constructor(
++		public readonly suppressPopup?: boolean
++	) { }
+ }
+ export class ReconnectionPermanentFailureEvent {
+ 	public readonly type = PersistentConnectionEventType.ReconnectionPermanentFailure;
++	constructor(
++		public readonly suppressPopup?: boolean | undefined
++	) { }
+ }
+ export type PersistenConnectionEvent = ConnectionGainEvent | ConnectionLostEvent | ReconnectionWaitEvent | ReconnectionRunningEvent | ReconnectionPermanentFailureEvent;
+ 
+@@ -411,16 +424,20 @@ abstract class PersistentConnection extends Disposable {
+ 		}
+ 		const logPrefix = commonLogPrefix(this._connectionType, this.reconnectionToken, true);
  		this._options.logService.info(`${logPrefix} starting reconnecting loop. You can get more information with the trace log level.`);
- 		this._onDidStateChange.fire(new ConnectionLostEvent());
+-		this._onDidStateChange.fire(new ConnectionLostEvent());
++		let suppressPopup = true;
++		this._onDidStateChange.fire(new ConnectionLostEvent(suppressPopup));
  		const TIMES = [5, 5, 10, 10, 10, 10, 10, 30];
-+		// const SHOW_POPUP_ON_ATTEMPT = 2 // aka third attempt
++		const SHOW_POPUP_ON_ATTEMPT = 2 // aka third attempt
 +		
  		const disconnectStartTime = Date.now();
  		let attempt = -1;
  		do {
+ 			attempt++;
++			suppressPopup = (attempt < SHOW_POPUP_ON_ATTEMPT) ? true : false
+ 			const waitTime = (attempt < TIMES.length ? TIMES[attempt] : TIMES[TIMES.length - 1]);
+ 			try {
+ 				const sleepPromise = sleep(waitTime);
+-				this._onDidStateChange.fire(new ReconnectionWaitEvent(waitTime, sleepPromise));
++				this._onDidStateChange.fire(new ReconnectionWaitEvent(waitTime, sleepPromise, suppressPopup));
+ 
+ 				this._options.logService.info(`${logPrefix} waiting for ${waitTime} seconds before reconnecting...`);
+ 				try {
+@@ -433,7 +450,7 @@ abstract class PersistentConnection extends Disposable {
+ 				}
+ 
+ 				// connection was lost, let's try to re-establish it
+-				this._onDidStateChange.fire(new ReconnectionRunningEvent());
++				this._onDidStateChange.fire(new ReconnectionRunningEvent(suppressPopup));
+ 				this._options.logService.info(`${logPrefix} resolving connection...`);
+ 				const simpleOptions = await resolveConnectionOptions(this._options, this.reconnectionToken, this.protocol);
+ 				this._options.logService.info(`${logPrefix} connecting to ${simpleOptions.host}:${simpleOptions.port}...`);
 diff --git a/src/vs/platform/storage/browser/storageService.ts b/src/vs/platform/storage/browser/storageService.ts
 index ab3fd347b69f8a3d9b96e706cd87c911b8ffed6b..9d351037b577f9f1edfd18ae9b3c48a211f4467f 100644
 --- a/src/vs/platform/storage/browser/storageService.ts
@@ -3209,24 +3272,84 @@ index 94e7e7a4bac154c45078a1b5034e50634a7a43af..8164200dcef1efbc65b50eef9c270af3
  				this._dirnameKey.set(value ? dirname(value).fsPath : null);
  				this._pathKey.set(value ? value.fsPath : null);
 diff --git a/src/vs/workbench/contrib/remote/browser/remote.ts b/src/vs/workbench/contrib/remote/browser/remote.ts
-index 98573a206f14928fc3fdf18fe927cb75034e4ad1..2f6a2fd6733e286024d20530773e3fbc26ffe16c 100644
+index 98573a206f14928fc3fdf18fe927cb75034e4ad1..3ffe27b816e2d0a630985a24dd1af910877c2295 100644
 --- a/src/vs/workbench/contrib/remote/browser/remote.ts
 +++ b/src/vs/workbench/contrib/remote/browser/remote.ts
-@@ -795,10 +795,10 @@ class RemoteAgentConnectionStatusListener implements IWorkbenchContribution {
- 				}
+@@ -635,7 +635,7 @@ class VisibleProgress {
+ 		return this._lastReport;
+ 	}
+ 
+-	constructor(progressService: IProgressService, location: ProgressLocation, initialReport: string | null, buttons: string[], onDidCancel: (choice: number | undefined, lastReport: string | null) => void) {
++	constructor(progressService: IProgressService, location: ProgressLocation, initialReport: string | null, buttons: string[], onDidCancel: (choice: number | undefined, lastReport: string | null) => void, suppressPopup: Boolean | undefined) {
+ 		this._isDisposed = false;
+ 		this._lastReport = initialReport;
+ 		this._currentProgressPromiseResolve = null;
+@@ -644,8 +644,10 @@ class VisibleProgress {
+ 
+ 		const promise = new Promise<void>((resolve) => this._currentProgressPromiseResolve = resolve);
+ 
++		const options = suppressPopup ? { location: location, buttons: buttons, silent: suppressPopup } : { location: location, buttons: buttons }
++
+ 		progressService.withProgress(
+-			{ location: location, buttons: buttons },
++			options,
+ 			(progress) => { if (!this._isDisposed) { this._currentProgress = progress; } return promise; },
+ 			(choice) => onDidCancel(choice, this._lastReport)
+ 		);
+@@ -736,7 +738,7 @@ class RemoteAgentConnectionStatusListener implements IWorkbenchContribution {
+ 			let reconnectWaitEvent: ReconnectionWaitEvent | null = null;
+ 			let disposableListener: IDisposable | null = null;
+ 
+-			function showProgress(location: ProgressLocation.Dialog | ProgressLocation.Notification, buttons: { label: string, callback: () => void }[], initialReport: string | null = null): VisibleProgress {
++			function showProgress(location: ProgressLocation.Dialog | ProgressLocation.Notification, buttons: { label: string, callback: () => void }[], initialReport: string | null = null, suppressPopup: Boolean | undefined): VisibleProgress {
+ 				if (visibleProgress) {
+ 					visibleProgress.dispose();
+ 					visibleProgress = null;
+@@ -752,12 +754,12 @@ class RemoteAgentConnectionStatusListener implements IWorkbenchContribution {
+ 							buttons[choice].callback();
+ 						} else {
+ 							if (location === ProgressLocation.Dialog) {
+-								visibleProgress = showProgress(ProgressLocation.Notification, buttons, lastReport);
++								visibleProgress = showProgress(ProgressLocation.Notification, buttons, lastReport, suppressPopup);
+ 							} else {
+ 								hideProgress();
+ 							}
+ 						}
+-					}
++					}, suppressPopup
+ 				);
+ 			}
+ 
+@@ -796,17 +798,17 @@ class RemoteAgentConnectionStatusListener implements IWorkbenchContribution {
  				switch (e.type) {
  					case PersistentConnectionEventType.ConnectionLost:
--						if (!visibleProgress) {
+ 						if (!visibleProgress) {
 -							visibleProgress = showProgress(ProgressLocation.Dialog, [reconnectButton, reloadButton]);
--						}
--						visibleProgress.report(nls.localize('connectionLost', "Connection Lost"));
-+						// if (!visibleProgress) {
-+						// 	visibleProgress = showProgress(ProgressLocation.Dialog, [reconnectButton, reloadButton]);
-+						// }
-+						// visibleProgress.report(nls.localize('connectionLost', "Connection Lost"));
++							visibleProgress = showProgress(ProgressLocation.Notification, [reconnectButton, reloadButton], null, e.suppressPopup);
+ 						}
+ 						visibleProgress.report(nls.localize('connectionLost', "Connection Lost"));
  						break;
  					case PersistentConnectionEventType.ReconnectionWait:
  						reconnectWaitEvent = e;
+-						visibleProgress = showProgress(lastLocation || ProgressLocation.Notification, [reconnectButton, reloadButton]);
++						visibleProgress = showProgress(lastLocation || ProgressLocation.Dialog, [reconnectButton, reloadButton], null, e.suppressPopup);
+ 						visibleProgress.startTimer(Date.now() + 1000 * e.durationSeconds);
+ 						break;
+ 					case PersistentConnectionEventType.ReconnectionRunning:
+-						visibleProgress = showProgress(lastLocation || ProgressLocation.Notification, [reloadButton]);
++						visibleProgress = showProgress(lastLocation || ProgressLocation.Notification, [reloadButton], null, e.suppressPopup);
+ 						visibleProgress.report(nls.localize('reconnectionRunning', "Attempting to reconnect..."));
+ 
+ 						// Register to listen for quick input is opened
+@@ -815,7 +817,7 @@ class RemoteAgentConnectionStatusListener implements IWorkbenchContribution {
+ 							if (contextKeyChangeEvent.affectsSome(reconnectInteraction)) {
+ 								// Need to move from dialog if being shown and user needs to type in a prompt
+ 								if (lastLocation === ProgressLocation.Dialog && visibleProgress !== null) {
+-									visibleProgress = showProgress(ProgressLocation.Notification, [reloadButton], visibleProgress.lastReport);
++									visibleProgress = showProgress(ProgressLocation.Notification, [reloadButton], visibleProgress.lastReport, e.suppressPopup);
+ 								}
+ 							}
+ 						});
 diff --git a/src/vs/workbench/contrib/scm/browser/media/scm.css b/src/vs/workbench/contrib/scm/browser/media/scm.css
 index ac44ad3bae428def66e22fe9cc1c54648d429f6b..faa63023c4c586b51fa3c2a48ff3641b9cb0e145 100644
 --- a/src/vs/workbench/contrib/scm/browser/media/scm.css

--- a/ci/dev/vscode.patch
+++ b/ci/dev/vscode.patch
@@ -689,7 +689,7 @@ index 3715cbb8e6ee41c3d9b5090918d243b723ae2d00..c65de8ad37e727d66da97a8f8b170cbc
 -
 -
 diff --git a/src/vs/platform/remote/common/remoteAgentConnection.ts b/src/vs/platform/remote/common/remoteAgentConnection.ts
-index 18d3d04fd20335975293e37b3b641120dd92da20..b9819d50683f40c41c8a3b1f71423a20916e8394 100644
+index 18d3d04fd20335975293e37b3b641120dd92da20..a06f20ece490dba5d88b41268cddaaf6b2f6b64a 100644
 --- a/src/vs/platform/remote/common/remoteAgentConnection.ts
 +++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
 @@ -92,7 +92,7 @@ async function connectToRemoteExtensionHostAgent(options: ISimpleConnectionOptio
@@ -701,12 +701,12 @@ index 18d3d04fd20335975293e37b3b641120dd92da20..b9819d50683f40c41c8a3b1f71423a20
  			(err: any, socket: ISocket | undefined) => {
  				if (err || !socket) {
  					options.logService.error(`${logPrefix} socketFactory.connect() failed. Error:`);
-@@ -331,12 +331,17 @@ export const enum PersistentConnectionEventType {
+@@ -331,12 +331,16 @@ export const enum PersistentConnectionEventType {
  }
  export class ConnectionLostEvent {
  	public readonly type = PersistentConnectionEventType.ConnectionLost;
 +	constructor(
-+		public readonly suppressPopup?: boolean
++		public readonly connectionAttempt?: number
 +	) { }
  }
  export class ReconnectionWaitEvent {
@@ -715,67 +715,68 @@ index 18d3d04fd20335975293e37b3b641120dd92da20..b9819d50683f40c41c8a3b1f71423a20
  		public readonly durationSeconds: number,
 -		private readonly cancellableTimer: CancelablePromise<void>
 +		private readonly cancellableTimer: CancelablePromise<void>,
-+		public readonly suppressPopup?: boolean,
-+		public readonly forceDialog?: boolean
++		public readonly connectionAttempt?: number,
  	) { }
  
  	public skipWait(): void {
-@@ -345,12 +350,21 @@ export class ReconnectionWaitEvent {
+@@ -345,12 +349,21 @@ export class ReconnectionWaitEvent {
  }
  export class ReconnectionRunningEvent {
  	public readonly type = PersistentConnectionEventType.ReconnectionRunning;
 +	constructor(
-+		public readonly suppressPopup?: boolean
++		public readonly connectionAttempt?: number
 +	) { }
  }
  export class ConnectionGainEvent {
  	public readonly type = PersistentConnectionEventType.ConnectionGain;
 +	constructor(
-+		public readonly suppressPopup?: boolean
++		public readonly connectionAttempt?: number
 +	) { }
  }
  export class ReconnectionPermanentFailureEvent {
  	public readonly type = PersistentConnectionEventType.ReconnectionPermanentFailure;
 +	constructor(
-+		public readonly suppressPopup?: boolean | undefined
++		public readonly connectionAttempt?: number
 +	) { }
  }
  export type PersistenConnectionEvent = ConnectionGainEvent | ConnectionLostEvent | ReconnectionWaitEvent | ReconnectionRunningEvent | ReconnectionPermanentFailureEvent;
  
-@@ -411,16 +425,22 @@ abstract class PersistentConnection extends Disposable {
+@@ -411,8 +424,9 @@ abstract class PersistentConnection extends Disposable {
  		}
  		const logPrefix = commonLogPrefix(this._connectionType, this.reconnectionToken, true);
  		this._options.logService.info(`${logPrefix} starting reconnecting loop. You can get more information with the trace log level.`);
 -		this._onDidStateChange.fire(new ConnectionLostEvent());
-+		let suppressPopup = true;
-+		let forceDialog = false;
-+		this._onDidStateChange.fire(new ConnectionLostEvent(suppressPopup));
++		this._onDidStateChange.fire(new ConnectionLostEvent(0));
  		const TIMES = [5, 5, 10, 10, 10, 10, 10, 30];
-+		const SHOW_POPUP_ON_ATTEMPT = 2 // aka third attempt
 +		
  		const disconnectStartTime = Date.now();
  		let attempt = -1;
  		do {
- 			attempt++;
-+			suppressPopup = (attempt < SHOW_POPUP_ON_ATTEMPT) ? true : false
-+			forceDialog = (attempt == SHOW_POPUP_ON_ATTEMPT)
+@@ -420,7 +434,7 @@ abstract class PersistentConnection extends Disposable {
  			const waitTime = (attempt < TIMES.length ? TIMES[attempt] : TIMES[TIMES.length - 1]);
  			try {
  				const sleepPromise = sleep(waitTime);
 -				this._onDidStateChange.fire(new ReconnectionWaitEvent(waitTime, sleepPromise));
-+				this._onDidStateChange.fire(new ReconnectionWaitEvent(waitTime, sleepPromise, suppressPopup, forceDialog));
++				this._onDidStateChange.fire(new ReconnectionWaitEvent(waitTime, sleepPromise, attempt));
  
  				this._options.logService.info(`${logPrefix} waiting for ${waitTime} seconds before reconnecting...`);
  				try {
-@@ -433,7 +453,7 @@ abstract class PersistentConnection extends Disposable {
+@@ -433,13 +447,13 @@ abstract class PersistentConnection extends Disposable {
  				}
  
  				// connection was lost, let's try to re-establish it
 -				this._onDidStateChange.fire(new ReconnectionRunningEvent());
-+				this._onDidStateChange.fire(new ReconnectionRunningEvent(suppressPopup));
++				this._onDidStateChange.fire(new ReconnectionRunningEvent(attempt));
  				this._options.logService.info(`${logPrefix} resolving connection...`);
  				const simpleOptions = await resolveConnectionOptions(this._options, this.reconnectionToken, this.protocol);
  				this._options.logService.info(`${logPrefix} connecting to ${simpleOptions.host}:${simpleOptions.port}...`);
+ 				await connectWithTimeLimit(simpleOptions.logService, this._reconnect(simpleOptions), RECONNECT_TIMEOUT);
+ 				this._options.logService.info(`${logPrefix} reconnected!`);
+-				this._onDidStateChange.fire(new ConnectionGainEvent());
++				this._onDidStateChange.fire(new ConnectionGainEvent(attempt));
+ 
+ 				break;
+ 			} catch (err) {
 diff --git a/src/vs/platform/storage/browser/storageService.ts b/src/vs/platform/storage/browser/storageService.ts
 index ab3fd347b69f8a3d9b96e706cd87c911b8ffed6b..9d351037b577f9f1edfd18ae9b3c48a211f4467f 100644
 --- a/src/vs/platform/storage/browser/storageService.ts
@@ -3275,16 +3276,28 @@ index 94e7e7a4bac154c45078a1b5034e50634a7a43af..8164200dcef1efbc65b50eef9c270af3
  				this._dirnameKey.set(value ? dirname(value).fsPath : null);
  				this._pathKey.set(value ? value.fsPath : null);
 diff --git a/src/vs/workbench/contrib/remote/browser/remote.ts b/src/vs/workbench/contrib/remote/browser/remote.ts
-index 98573a206f14928fc3fdf18fe927cb75034e4ad1..a031f76924abf8f10c510ea9c043f670c5b43074 100644
+index 98573a206f14928fc3fdf18fe927cb75034e4ad1..1430666aa94f941bda086df503fec8b35aa2b25f 100644
 --- a/src/vs/workbench/contrib/remote/browser/remote.ts
 +++ b/src/vs/workbench/contrib/remote/browser/remote.ts
-@@ -795,31 +795,43 @@ class RemoteAgentConnectionStatusListener implements IWorkbenchContribution {
+@@ -730,6 +730,7 @@ class RemoteAgentConnectionStatusListener implements IWorkbenchContribution {
+ 		@IContextKeyService contextKeyService: IContextKeyService
+ 	) {
+ 		const connection = remoteAgentService.getConnection();
++		const SHOW_POPUP_ON_ATTEMPT = 2 // aka third attempt
+ 		if (connection) {
+ 			let visibleProgress: VisibleProgress | null = null;
+ 			let lastLocation: ProgressLocation.Dialog | ProgressLocation.Notification | null = null;
+@@ -793,33 +794,47 @@ class RemoteAgentConnectionStatusListener implements IWorkbenchContribution {
+ 					disposableListener.dispose();
+ 					disposableListener = null;
  				}
++				let suppressPopup = (typeof e.connectionAttempt == 'number' && e.connectionAttempt < SHOW_POPUP_ON_ATTEMPT)
++				let forceDialog = (typeof e.connectionAttempt == 'number' && e.connectionAttempt == SHOW_POPUP_ON_ATTEMPT)
  				switch (e.type) {
  					case PersistentConnectionEventType.ConnectionLost:
 -						if (!visibleProgress) {
 -							visibleProgress = showProgress(ProgressLocation.Dialog, [reconnectButton, reloadButton]);
-+						if (e.suppressPopup) {
++						if (suppressPopup) {
 +							hideProgress()
 +						} else {
 +							if (!visibleProgress) {
@@ -3298,10 +3311,10 @@ index 98573a206f14928fc3fdf18fe927cb75034e4ad1..a031f76924abf8f10c510ea9c043f670
  						reconnectWaitEvent = e;
 -						visibleProgress = showProgress(lastLocation || ProgressLocation.Notification, [reconnectButton, reloadButton]);
 -						visibleProgress.startTimer(Date.now() + 1000 * e.durationSeconds);
-+						if (e.suppressPopup) {
++						if (suppressPopup) {
 +							hideProgress()
 +						} else {
-+							const location = e.forceDialog ? ProgressLocation.Dialog : (lastLocation || ProgressLocation.Notification)
++							const location = forceDialog ? ProgressLocation.Dialog : (lastLocation || ProgressLocation.Notification)
 +							visibleProgress = showProgress(location, [reconnectButton, reloadButton]);
 +							visibleProgress.startTimer(Date.now() + 1000 * e.durationSeconds);	
 +						}
@@ -3317,7 +3330,7 @@ index 98573a206f14928fc3fdf18fe927cb75034e4ad1..a031f76924abf8f10c510ea9c043f670
 -								// Need to move from dialog if being shown and user needs to type in a prompt
 -								if (lastLocation === ProgressLocation.Dialog && visibleProgress !== null) {
 -									visibleProgress = showProgress(ProgressLocation.Notification, [reloadButton], visibleProgress.lastReport);
-+						if (e.suppressPopup) {
++						if (suppressPopup) {
 +							hideProgress()
 +						} else {
 +							visibleProgress = showProgress(lastLocation || ProgressLocation.Notification, [reloadButton]);

--- a/ci/dev/vscode.patch
+++ b/ci/dev/vscode.patch
@@ -689,7 +689,7 @@ index 3715cbb8e6ee41c3d9b5090918d243b723ae2d00..c65de8ad37e727d66da97a8f8b170cbc
 -
 -
 diff --git a/src/vs/platform/remote/common/remoteAgentConnection.ts b/src/vs/platform/remote/common/remoteAgentConnection.ts
-index 18d3d04fd20335975293e37b3b641120dd92da20..4ec77056f8b707cb9cfc6af28f995d644b127506 100644
+index 18d3d04fd20335975293e37b3b641120dd92da20..b9819d50683f40c41c8a3b1f71423a20916e8394 100644
 --- a/src/vs/platform/remote/common/remoteAgentConnection.ts
 +++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
 @@ -92,7 +92,7 @@ async function connectToRemoteExtensionHostAgent(options: ISimpleConnectionOptio
@@ -747,11 +747,10 @@ index 18d3d04fd20335975293e37b3b641120dd92da20..4ec77056f8b707cb9cfc6af28f995d64
  		const logPrefix = commonLogPrefix(this._connectionType, this.reconnectionToken, true);
  		this._options.logService.info(`${logPrefix} starting reconnecting loop. You can get more information with the trace log level.`);
 -		this._onDidStateChange.fire(new ConnectionLostEvent());
--		const TIMES = [5, 5, 10, 10, 10, 10, 10, 30];
 +		let suppressPopup = true;
 +		let forceDialog = false;
 +		this._onDidStateChange.fire(new ConnectionLostEvent(suppressPopup));
-+		const TIMES = [1, 2, 3, 10, 10, 10, 10, 30];
+ 		const TIMES = [5, 5, 10, 10, 10, 10, 10, 30];
 +		const SHOW_POPUP_ON_ATTEMPT = 2 // aka third attempt
 +		
  		const disconnectStartTime = Date.now();

--- a/ci/dev/vscode.patch
+++ b/ci/dev/vscode.patch
@@ -689,7 +689,7 @@ index 3715cbb8e6ee41c3d9b5090918d243b723ae2d00..c65de8ad37e727d66da97a8f8b170cbc
 -
 -
 diff --git a/src/vs/platform/remote/common/remoteAgentConnection.ts b/src/vs/platform/remote/common/remoteAgentConnection.ts
-index 18d3d04fd20335975293e37b3b641120dd92da20..e072fc38ccd950462f42fdf112c8e7e673f351f5 100644
+index 18d3d04fd20335975293e37b3b641120dd92da20..48ba6434bd5fbd96919b1e109f350016b97aadc0 100644
 --- a/src/vs/platform/remote/common/remoteAgentConnection.ts
 +++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
 @@ -92,7 +92,7 @@ async function connectToRemoteExtensionHostAgent(options: ISimpleConnectionOptio
@@ -701,53 +701,15 @@ index 18d3d04fd20335975293e37b3b641120dd92da20..e072fc38ccd950462f42fdf112c8e7e6
  			(err: any, socket: ISocket | undefined) => {
  				if (err || !socket) {
  					options.logService.error(`${logPrefix} socketFactory.connect() failed. Error:`);
-@@ -411,16 +411,23 @@ abstract class PersistentConnection extends Disposable {
- 		}
- 		const logPrefix = commonLogPrefix(this._connectionType, this.reconnectionToken, true);
+@@ -413,6 +413,8 @@ abstract class PersistentConnection extends Disposable {
  		this._options.logService.info(`${logPrefix} starting reconnecting loop. You can get more information with the trace log level.`);
--		this._onDidStateChange.fire(new ConnectionLostEvent());
+ 		this._onDidStateChange.fire(new ConnectionLostEvent());
  		const TIMES = [5, 5, 10, 10, 10, 10, 10, 30];
-+		const SHOW_POPUP_ON_ATTEMPT = 2 // aka third attempt
++		// const SHOW_POPUP_ON_ATTEMPT = 2 // aka third attempt
 +		
  		const disconnectStartTime = Date.now();
  		let attempt = -1;
  		do {
- 			attempt++;
-+			if (attempt == SHOW_POPUP_ON_ATTEMPT){
-+				this._onDidStateChange.fire(new ConnectionLostEvent());
-+			}
-+
- 			const waitTime = (attempt < TIMES.length ? TIMES[attempt] : TIMES[TIMES.length - 1]);
- 			try {
- 				const sleepPromise = sleep(waitTime);
--				this._onDidStateChange.fire(new ReconnectionWaitEvent(waitTime, sleepPromise));
-+				if (attempt >= SHOW_POPUP_ON_ATTEMPT) {
-+					this._onDidStateChange.fire(new ReconnectionWaitEvent(waitTime, sleepPromise));
-+				}
- 
- 				this._options.logService.info(`${logPrefix} waiting for ${waitTime} seconds before reconnecting...`);
- 				try {
-@@ -433,14 +440,17 @@ abstract class PersistentConnection extends Disposable {
- 				}
- 
- 				// connection was lost, let's try to re-establish it
--				this._onDidStateChange.fire(new ReconnectionRunningEvent());
-+				if (attempt >= SHOW_POPUP_ON_ATTEMPT){
-+					this._onDidStateChange.fire(new ReconnectionRunningEvent());
-+				}
- 				this._options.logService.info(`${logPrefix} resolving connection...`);
- 				const simpleOptions = await resolveConnectionOptions(this._options, this.reconnectionToken, this.protocol);
- 				this._options.logService.info(`${logPrefix} connecting to ${simpleOptions.host}:${simpleOptions.port}...`);
- 				await connectWithTimeLimit(simpleOptions.logService, this._reconnect(simpleOptions), RECONNECT_TIMEOUT);
- 				this._options.logService.info(`${logPrefix} reconnected!`);
--				this._onDidStateChange.fire(new ConnectionGainEvent());
--
-+				if (attempt >= SHOW_POPUP_ON_ATTEMPT) {
-+					this._onDidStateChange.fire(new ConnectionGainEvent());
-+				}
- 				break;
- 			} catch (err) {
- 				if (err.code === 'VSCODE_CONNECTION_ERROR') {
 diff --git a/src/vs/platform/storage/browser/storageService.ts b/src/vs/platform/storage/browser/storageService.ts
 index ab3fd347b69f8a3d9b96e706cd87c911b8ffed6b..9d351037b577f9f1edfd18ae9b3c48a211f4467f 100644
 --- a/src/vs/platform/storage/browser/storageService.ts
@@ -3246,6 +3208,25 @@ index 94e7e7a4bac154c45078a1b5034e50634a7a43af..8164200dcef1efbc65b50eef9c270af3
  				this._filenameKey.set(value ? basename(value) : null);
  				this._dirnameKey.set(value ? dirname(value).fsPath : null);
  				this._pathKey.set(value ? value.fsPath : null);
+diff --git a/src/vs/workbench/contrib/remote/browser/remote.ts b/src/vs/workbench/contrib/remote/browser/remote.ts
+index 98573a206f14928fc3fdf18fe927cb75034e4ad1..2f6a2fd6733e286024d20530773e3fbc26ffe16c 100644
+--- a/src/vs/workbench/contrib/remote/browser/remote.ts
++++ b/src/vs/workbench/contrib/remote/browser/remote.ts
+@@ -795,10 +795,10 @@ class RemoteAgentConnectionStatusListener implements IWorkbenchContribution {
+ 				}
+ 				switch (e.type) {
+ 					case PersistentConnectionEventType.ConnectionLost:
+-						if (!visibleProgress) {
+-							visibleProgress = showProgress(ProgressLocation.Dialog, [reconnectButton, reloadButton]);
+-						}
+-						visibleProgress.report(nls.localize('connectionLost', "Connection Lost"));
++						// if (!visibleProgress) {
++						// 	visibleProgress = showProgress(ProgressLocation.Dialog, [reconnectButton, reloadButton]);
++						// }
++						// visibleProgress.report(nls.localize('connectionLost', "Connection Lost"));
+ 						break;
+ 					case PersistentConnectionEventType.ReconnectionWait:
+ 						reconnectWaitEvent = e;
 diff --git a/src/vs/workbench/contrib/scm/browser/media/scm.css b/src/vs/workbench/contrib/scm/browser/media/scm.css
 index ac44ad3bae428def66e22fe9cc1c54648d429f6b..faa63023c4c586b51fa3c2a48ff3641b9cb0e145 100644
 --- a/src/vs/workbench/contrib/scm/browser/media/scm.css


### PR DESCRIPTION
Issue this PR solves: https://github.com/cdr/code-server/issues/1791

On a connection loss, the client attempts to reconnect up to twice in the background before displaying the reconnection pop-up.
